### PR TITLE
Use rbw instead of the bitwarden-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ to your flake inputs.
 The script exports a binary called `work-vpn` in its default package, which
 depends on a few environment variables:
 
-- `BW_SESSION`: A BitWarden Session key, which can be obtained by running `bw
-  login`.
-- `OPENVPN_BW_ID`: The ID of the BitWarden secret in which the credentials are
-  stored.
+- `OPENVPN_BW_ID`: The ID or name of the BitWarden secret in which the
+  credentials are stored.
 - `OPENVPN_URL`: URL of the OpenVPN server to connect to.
 - `OPENVPN_URL_STAGE`: Alternative URL to connect to when using the `-s` or
   `--staging` flag.
@@ -51,7 +49,6 @@ dotenv_if_exists .env.local
 ### `.env.local`
 
 ```sh
-export BW_SESSION=...
 export OPENVPN_BW_ID=...
 export OPENVPN_CHALLENGE_PREFIX=...
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,13 @@
         packages.default = with pkgs.lib; let
           ask-password = getExe' pkgs.systemd "systemd-tty-ask-password-agent";
           bc = getExe pkgs.bc;
-          bw = getExe pkgs.bitwarden-cli;
           cat = getExe' pkgs.coreutils "cat";
           echo = getExe' pkgs.coreutils "echo";
           grep = getExe pkgs.gnugrep;
-          jq = getExe pkgs.jq;
           mkfifo = getExe' pkgs.coreutils "mkfifo";
           mktemp = getExe' pkgs.coreutils "mktemp";
           openvpn = getExe pkgs.openvpn;
+          rbw = getExe pkgs.rbw;
           reply-password = "${pkgs.systemd}/lib/systemd/systemd-reply-password";
           rm = getExe' pkgs.coreutils "rm";
           rmdir = getExe' pkgs.coreutils "rmdir";
@@ -66,12 +65,8 @@
               esac
             done
 
-            # Ensure BitWarden is logged in.
-            if [ -z "''\${BW_SESSION:-}:" ]; then
-              ${echo} "BW_SESSION environment variable is not set."
-              ${echo} "Run \`bw login\` to acquire a session ID and re-run this command."
-              exit 1
-            fi
+            # Ensure RBW is logged in.
+            ${rbw} login
 
             # BitWarden credentials identifier.
             # This is where the VPN username & password are stored.
@@ -92,28 +87,16 @@
             fi
 
             # Extract OpenVPN username & password.
-            ${echo} "BitWarden: extracting username..."
-            USER="$(${bw} get item $OPENVPN_BW_ID | ${jq} -r .login.username)"
-            ${echo} "BitWarden: extracting password..."
-            PASS="$(${bw} get item $OPENVPN_BW_ID | ${jq} -r .login.password)"
+            USER="$(${rbw} get $OPENVPN_BW_ID --field username)"
+            USER="$(${rbw} get $OPENVPN_BW_ID --field password)"
 
             # Extract OpenVPN CA.
             # It should be saved in BitWarden under the openvpn_client_key field.
-            ${echo} "BitWarden: extracting certificate authority..."
-            OPENVPN_CA="$(
-              ${bw} get item $OPENVPN_BW_ID |
-                ${jq} -r '.fields[] | select(.name == "openvpn_ca").value' |
-                ${tr} ' ' \\n
-            )"
+            OPENVPN_CA="$(${rbw} get $OPENVPN_BW_ID --field openvpn_ca)"
 
             # Extract OpenVPN TLS client key.
             # It should be saved in BitWarden under the openvpn_client_key field.
-            ${echo} "BitWarden: extracting client key..."
-            OPENVPN_TLS_CLIENT_KEY="$(
-              ${bw} get item $OPENVPN_BW_ID |
-                ${jq} -r '.fields[] | select(.name == "openvpn_tls_client_key").value' |
-                ${tr} ' ' \\n
-            )"
+            OPENVPN_TLS_CLIENT_KEY="$(${rbw} get $OPENVPN_BW_ID --field openvpn_tls_client_key)"
 
             CREDS_DIR="$(${mktemp} --directory)"
             CREDS_FIFO="$CREDS_DIR/credentials"

--- a/flake.nix
+++ b/flake.nix
@@ -75,8 +75,8 @@
 
             # Ensure RBW is logged in.
             if ! ${rbw} login; then
-              ${echo} "Bitwarden login failed. Make sure \`rbw\` is installed and the"
-              ${echo} "\`rbw-agent\` is running. Type \`rbw login\` to get started."
+              ${echo} "Bitwarden login failed. Make sure \`rbw\` is installed and the \`rbw-agent\`"
+              ${echo} "is running. Install \`rbw\` and type \`rbw login\` to get started."
               exit 3
             fi
 


### PR DESCRIPTION
`rbw` is massively faster and doesn't require passing around the session secret in an environment variable (yuck!), instead it is handled securely by an agent.

This also makes configuration simpler and safer.