### PR TITLE
Use writeShellApplication for the shell app

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
         "type": "github"
       },
       "original": {
@@ -36,14 +36,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,26 +10,20 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux"];
       perSystem = {pkgs, ...}: {
-        packages.default = with pkgs.lib; let
-          ask-password = getExe' pkgs.systemd "systemd-tty-ask-password-agent";
-          bc = getExe pkgs.bc;
-          cat = getExe' pkgs.coreutils "cat";
-          echo = getExe' pkgs.coreutils "echo";
-          grep = getExe pkgs.gnugrep;
-          mkfifo = getExe' pkgs.coreutils "mkfifo";
-          mktemp = getExe' pkgs.coreutils "mktemp";
-          openvpn = getExe pkgs.openvpn;
-          rbw = getExe pkgs.rbw;
-          reply-password = "${pkgs.systemd}/lib/systemd/systemd-reply-password";
-          rm = getExe' pkgs.coreutils "rm";
-          rmdir = getExe' pkgs.coreutils "rmdir";
-          sed = getExe pkgs.gnused;
-          sleep = getExe' pkgs.coreutils "sleep";
-          tr = getExe' pkgs.coreutils "tr";
-          update-resolv-conf = "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf";
-          wc = getExe' pkgs.coreutils "wc";
-        in
-          pkgs.writeShellScriptBin "work-vpn" ''
+        packages.default = pkgs.writeShellApplication {
+          name = "work-vpn";
+          runtimeInputs = with pkgs; [
+            bc
+            coreutils
+            gnugrep
+            gnused
+            openvpn
+            rbw
+            sudo
+            systemd
+            update-resolv-conf
+          ];
+          text = ''
             set -euo pipefail
 
             while getopts ":vs-:" opt; do
@@ -68,21 +62,21 @@
             # Bitwarden credentials identifier.
             # This is where the VPN username & password are stored.
             if [ -z "''\${OPENVPN_BW_ID:-}" ]; then
-              ${echo} "OPENVPN_BW_ID environment variable is not set."
-              ${echo} "Store work credentials in Bitwarden and set the UUID in \`.env.local\`."
+              echo "OPENVPN_BW_ID environment variable is not set."
+              echo "Store work credentials in Bitwarden and set the UUID in \`.env.local\`."
               exit 2
             fi
 
             # Ensure RBW is logged in.
-            if ! ${rbw} login; then
-              ${echo} "Bitwarden login failed. Make sure \`rbw\` is installed and the \`rbw-agent\`"
-              ${echo} "is running. Install \`rbw\` and type \`rbw login\` to get started."
+            if ! rbw login; then
+              echo "Bitwarden login failed. Make sure \`rbw\` is installed and the \`rbw-agent\`"
+              echo "is running. Install \`rbw\` and type \`rbw login\` to get started."
               exit 3
             fi
 
             # Ensure RBW is unlocked.
-            if ! ${rbw} unlock; then
-              ${echo} "Bitwarden unlock failed. Try unlocking manually by running \`rbw unlock\`."
+            if ! rbw unlock; then
+              echo "Bitwarden unlock failed. Try unlocking manually by running \`rbw unlock\`."
               exit 4
             fi
 
@@ -96,17 +90,17 @@
               VERB=0
             fi
 
-            CREDS_DIR="$(${mktemp} --directory)"
+            CREDS_DIR="$(mktemp --directory)"
             CREDS_FIFO="$CREDS_DIR/credentials"
-            ${mkfifo} --mode=600 "$CREDS_FIFO"
+            mkfifo --mode=600 "$CREDS_FIFO"
 
-            cat <<EOF >$CREDS_FIFO &
-            $(${rbw} get $OPENVPN_BW_ID --field username)
-            $(${rbw} get $OPENVPN_BW_ID --field password)
+            cat <<EOF >"$CREDS_FIFO" &
+            $(rbw get "$OPENVPN_BW_ID" --field username)
+            $(rbw get "$OPENVPN_BW_ID" --field password)
             EOF
             CREDS_PID=$!
 
-            ${cat} <<EOF |
+            cat <<EOF |
             client
             nobind
 
@@ -137,8 +131,8 @@
 
             # Update resolv.conf when connected.
             # Needed to get internal domains to resolve.
-            up ${update-resolv-conf}
-            down ${update-resolv-conf}
+            up "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"
+            down "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"
             script-security 2
 
             # Access Server:
@@ -149,8 +143,8 @@
             <ca>
             -----BEGIN CERTIFICATE-----
             $(
-              ${rbw} get $OPENVPN_BW_ID --field openvpn_ca |
-                ${tr} ' ' \\n
+              rbw get "$OPENVPN_BW_ID" --field openvpn_ca |
+                tr ' ' \\n
             )
             -----END CERTIFICATE-----
             </ca>
@@ -160,50 +154,50 @@
             <tls-crypt-v2>
             -----BEGIN OpenVPN tls-crypt-v2 client key-----
             $(
-              ${rbw} get $OPENVPN_BW_ID --field openvpn_tls_client_key |
-                ${tr} ' ' \\n
+              rbw get "$OPENVPN_BW_ID" --field openvpn_tls_client_key |
+                tr ' ' \\n
             )
             -----END OpenVPN tls-crypt-v2 client key-----
             </tls-crypt-v2>
             EOF
-              sudo ${openvpn} --config /dev/stdin &
+              sudo openvpn --config /dev/stdin &
             START_PID=$!
 
             # Clean up temporary files.
             wait $CREDS_PID
-            ${rm} "$CREDS_FIFO"
-            ${rmdir} "$CREDS_DIR"
+            rm "$CREDS_FIFO"
+            rmdir "$CREDS_DIR"
 
             # Wait for 2nd factor prompt:
             CHALLENGE_PAT="CHALLENGE: "
             while [ "$(
-              ${ask-password} --list |
-                ${grep} "$CHALLENGE_PAT" |
-                ${wc} -l
+              systemd-tty-ask-password-agent --list |
+                grep -c "$CHALLENGE_PAT"
             )" -lt 1 ]; do
-              ${sleep} 0.2
+              sleep 0.2
             done
 
             RESPONSE="$OPENVPN_CHALLENGE_PREFIX$(
-              ${ask-password} --list |
-                ${grep} "$CHALLENGE_PAT" |
-                ${sed} --regexp-extended --expression 's/.*?([0-9]+)([x/+-])([0-9]+).*/\1\2\3/g' |
-                ${tr} x '*' |
-                ${bc}
+              systemd-tty-ask-password-agent --list |
+                grep "$CHALLENGE_PAT" |
+                sed --regexp-extended --expression 's/.*?([0-9]+)([x/+-])([0-9]+).*/\1\2\3/g' |
+                tr x '*' |
+                bc
             )"
             SOCKET="$(
-              ${grep} "^Socket=" $(
-                ${grep} --files-with-matches "$CHALLENGE_PAT" /run/systemd/ask-password/ask.*
-              ) |
-              ${sed} 's/.*=//'
+              grep "^Socket=" "$(
+                grep --files-with-matches "$CHALLENGE_PAT" /run/systemd/ask-password/ask.*
+              )" |
+              sed 's/.*=//'
             )"
 
-            ${echo} "$RESPONSE" |
-              sudo pkexec "${reply-password}" 1 "$SOCKET"
+            echo "$RESPONSE" |
+              sudo pkexec "${pkgs.systemd}/lib/systemd/systemd-reply-password" 1 "$SOCKET"
 
             # Give control back to the OpenVPN process:
             wait $START_PID
           '';
+        };
       };
     };
 }


### PR DESCRIPTION
This enables `shellcheck` tests which are now also fixed.

In preparation to add a systemd-resolved variant or flag for systems with DNSSEC + DoT.