### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,5 +1,8 @@
 name: Nix
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/attilaolah/work-vpn/security/code-scanning/2](https://github.com/attilaolah/work-vpn/security/code-scanning/2)

To fix the problem, define explicit, least-privilege `permissions` for the workflow or for the `check` job so that the `GITHUB_TOKEN` does not inherit potentially broad repository defaults. Since this workflow only needs to check out the code and run `nix flake check`, it only needs read access to repository contents.

The best fix without changing existing behavior is to add a `permissions` block at the workflow root level (right under `name: Nix` or under `on:`), setting `contents: read`. This will apply to all jobs in the workflow that do not declare their own `permissions`, including `check`. No other scopes appear necessary based on the shown steps: `actions/checkout` works with `contents: read`, and `cachix/install-nix-action` typically only needs to read repo contents; it uses the token for GitHub API access which is also satisfied with read permissions for this use case.

Concretely, in `.github/workflows/nix.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Nix` and the `on:` block. No imports or additional definitions are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for automated workflows by establishing repository access permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->